### PR TITLE
Fix 2 errors related to parsing messages

### DIFF
--- a/client/src/Core/Message/Message.cpp
+++ b/client/src/Core/Message/Message.cpp
@@ -28,7 +28,7 @@ Message::Message(const string &type, const json &info) {
 }
 
 string Message::toString() const {
-    return m_root_.dump();
+    return m_root_.dump(-1,' ',false, nlohmann::json::error_handler_t::replace);
 }
 
 void Message::setType(const string &type) {

--- a/client/src/Models/enums.cpp
+++ b/client/src/Models/enums.cpp
@@ -19,9 +19,9 @@ ResourceType EnumUtils::getResourceTypeByInt(int resourceType) {
     switch (resourceType)
     {
         case 0:
-            return BREAD;
-        case 1:
             return GRASS;
+        case 1:
+            return BREAD;
         case 2:
             return NONE;
         default:


### PR DESCRIPTION
Hi,
I fixed 2 issues in the source code of the Cpp-Client:
1) Error in parsing bytes 0x80 - 0xFF (The library has some restriction on parsing non-ASCII characters) fixed it in `Message.cpp`

2) After a few tests I found out that the GRASS and BREAD were being parsed interchangeably (Every GRASS cell is being seen as BREAD and every BREAD cell is being seen as GRASS). If I'm correct, when `resource_type == 0` the cell contains GRASS and in contrast when `resource_type == 1` the cell contains bread. If so, Please consider the changes I made in `enums.cpp` (which will fix the issue).
